### PR TITLE
Add support for deleting registry keys/values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ FakesAssemblies/
 Puppetfile.lock
 ext-modules
 example_env
+
+.bundle/
+.kitchen*/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,47 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: puppet_apply
+  manifests_path: spec/manifests
+  modules_path: ./.kitchen-modules
+  require_chef_for_busser: false
+  resolve_with_librarian_puppet: false
+
+platforms:
+  - name: windows-2012r2
+    driver_plugin: vagrant
+    driver_config:
+      box: red-gate/windows-2012r2
+    transport:
+      name: winrm
+      elevated: true
+
+verifier:
+  name: shell
+
+suites:
+  - name: default
+    provisioner:
+      manifest: default.pp
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/default_spec.rb
+  - name: deletekey
+    driver_config:
+      provision: true
+      vagrantfiles:
+        - spec/vagrantfiles/create_keys.rb # Custom vagrantfile to be merged and use so that we can do some additional setup for the test
+    provisioner:
+      manifest: deletekey.pp
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/deletekey_spec.rb
+  - name: deletekeysubname
+    driver_config:
+      provision: true
+      vagrantfiles:
+        - spec/vagrantfiles/create_keys.rb # Custom vagrantfile to be merged and use so that we can do some additional setup for the test
+    provisioner:
+      manifest: deletekeysubname.pp
+    verifier:
+      command: rspec -c -f d -I spec spec/acceptance/deletekeysubname_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,27 @@
+source 'https://rubygems.org'
+
+gem 'puppet-lint'
+
+gem 'test-kitchen', '~> 1.8.0'
+# A 'special' version of kitchen-puppet with added support for windows
+gem 'kitchen-puppet', :github  => 'red-gate/kitchen-puppet', :ref  => 'windows_support'
+gem 'kitchen-vagrant', '~> 0.20.0'
+
+# needed by the vagrant-winrm vagrant plugin which is needed by kitchen-vagrant in order to be able to use winrm
+gem 'winrm-fs', '~> 0.4'
+gem 'winrm-elevated', '~> 0.4'
+
+# We use serverspec to test the state of our servers
+gem 'serverspec', '~> 2.31.1'
+# use our fork of specinfra which has a fix for a winrm warning.
+# TODO: get that fix back into the main gem...
+gem 'specinfra', :github => 'red-gate/specinfra'
+
+# We use rake as our build engine
+gem 'rake', '~> 11.1.2'
+# This gem tells us how long each rake task takes.
+gem 'rake-performance'
+
+# We use r10k to download our puppet modules.
+# We do use our own fork which contains a fix/workaround for SSL validation on windows.
+gem 'r10k', :github => 'red-gate/r10k', :branch => '2.0.x'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,166 @@
+GIT
+  remote: git://github.com/red-gate/kitchen-puppet.git
+  revision: 67893085b3ca93855f2ad199c859ae8142adfa1a
+  ref: windows_support
+  specs:
+    kitchen-puppet (1.42.0)
+      net-ssh (~> 3)
+      test-kitchen (~> 1.4)
+
+GIT
+  remote: git://github.com/red-gate/r10k.git
+  revision: 48e49b7fbb006070ae50ba431a20cacbed47d2b0
+  branch: 2.0.x
+  specs:
+    r10k (2.0.3)
+      colored (= 1.2)
+      cri (~> 2.6.1)
+      faraday (~> 0.9.0)
+      faraday_middleware (~> 0.9.0)
+      faraday_middleware-multi_json (~> 0.0.6)
+      log4r (= 1.1.10)
+      minitar
+      multi_json (~> 1.10)
+      semantic_puppet (~> 0.1.0)
+
+GIT
+  remote: git://github.com/red-gate/specinfra.git
+  revision: d941d078df6d4b5e5dbff1feb8ee40a66804deed
+  specs:
+    specinfra (2.57.0)
+      net-scp
+      net-ssh (>= 2.7, < 4.0)
+      net-telnet
+      sfl
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    artifactory (2.3.3)
+    builder (3.2.2)
+    colored (1.2)
+    cri (2.6.1)
+      colored (~> 1.2)
+    diff-lcs (1.2.5)
+    erubis (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.9.2)
+      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware-multi_json (0.0.6)
+      faraday_middleware
+      multi_json
+    fast_gettext (1.1.0)
+    ffi (1.9.14-x64-mingw32)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.3)
+      fast_gettext
+      gettext (>= 3.0.2)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    httpclient (2.8.0)
+    kitchen-vagrant (0.20.0)
+      test-kitchen (~> 1.4)
+    little-plugger (1.1.4)
+    locale (2.1.2)
+    log4r (1.1.10)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    minitar (0.5.4)
+    mixlib-install (1.1.0)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+    mixlib-shellout (2.2.6-universal-mingw32)
+      win32-process (~> 0.8.2)
+      wmi-lite (~> 1.0)
+    mixlib-versioning (1.1.0)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.2.0)
+    net-telnet (0.1.1)
+    nori (2.6.0)
+    puppet-lint (2.0.0)
+    rake (11.1.2)
+    rake-performance (0.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.1)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubyntlm (0.6.0)
+    rubyzip (1.2.0)
+    safe_yaml (1.0.4)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
+    serverspec (2.31.1)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    sfl (2.2)
+    test-kitchen (1.8.0)
+      mixlib-install (~> 1.0, >= 1.0.4)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 4.0)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    text (1.3.1)
+    thor (0.19.1)
+    win32-process (0.8.3)
+      ffi (>= 1.0.0)
+    winrm (1.8.1)
+      builder (>= 2.1.2)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0)
+    winrm-elevated (0.4.0)
+      winrm (~> 1.5)
+      winrm-fs (~> 0.4.2)
+    winrm-fs (0.4.3)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 1.5)
+    wmi-lite (1.0.0)
+
+PLATFORMS
+  x64-mingw32
+
+DEPENDENCIES
+  kitchen-puppet!
+  kitchen-vagrant (~> 0.20.0)
+  puppet-lint
+  r10k!
+  rake (~> 11.1.2)
+  rake-performance
+  serverspec (~> 2.31.1)
+  specinfra!
+  test-kitchen (~> 1.8.0)
+  winrm-elevated (~> 0.4)
+  winrm-fs (~> 0.4)
+
+BUNDLED WITH
+   1.10.6

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,5 @@
+forge "https://forgeapi.puppetlabs.com"
+moduledir './.kitchen-modules'
+
+mod 'puppetlabs/powershell', '1.0.6'
+mod 'puppetlabs/stdlib'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-puppet-registrykey
-=============
+# puppet-virtualbox_windows
+A Puppet module to configure registry keys on windows
 
-A puppet module to hold a VERY basic registrykey resource to manage windows registry keys.
+## How to build
+```
+bundle install -path .bundle
+bundle exec rake
+bundle exec rake acceptance:kitchen
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,73 @@
+require 'rake'
+require 'rake_performance'
+require 'find'
+require 'fileutils'
+require "bundler/setup"
+
+# always destroy the kitchen when running within Teamcity
+destroy_strategy = ENV['TEAMCITY_VERSION'] ? 'always' : 'passing'
+ENV["VAGRANT_SERVER_URL"] = "http://vagrant.red-gate.com"
+
+namespace :acceptance do
+  task :installpuppetmodules do
+    sh "bundle exec r10k puppetfile install --verbose"
+  end
+
+  desc 'Execute the acceptance tests'
+  task :kitchen => [:installpuppetmodules] do |task, args|
+    begin
+      sh "kitchen test --destroy=#{destroy_strategy} --concurrency --log-level=info"
+    ensure
+      puts "##teamcity[publishArtifacts '#{Dir.pwd}/.kitchen/logs/*.log => logs.zip']"
+    end
+  end
+
+end
+
+namespace :check do
+  namespace :manifests do
+    desc 'Validate syntax for all manifests'
+    task :syntax do
+      Dir.glob('**/*.pp').each do |puppet_file|
+        Bundler.with_clean_env  do
+          # Use bundler.with_clean_env as the way bundler set ruby environment variables
+          # is killing puppet on windows.
+          # Note that we may instead want to add puppet to our Gemfiles but we are currently seeing
+          # gem dependency conflicts between test-kitchen and puppet...
+          # Since we already have puppet installed on our build/test agents, let's use it.
+          sh "puppet parser validate --parser future #{puppet_file}"
+        end
+      end
+    end
+
+    require 'puppet-lint/tasks/puppet-lint'
+    Rake::Task[:lint].clear
+    desc 'puppet-lint all the manifests'
+    PuppetLint::RakeTask.new :lint do |config|
+      # # Pattern of files to ignore
+      # config.ignore_paths = ['modules/apt', 'modules/stdlib']
+
+      # List of checks to disable
+      config.disable_checks = ['80chars', 'trailing_whitespace', '2sp_soft_tabs', 'hard_tabs']
+
+      # # Enable automatic fixing of problems, defaults to false
+      # config.fix = true
+    end
+  end
+
+  namespace :ruby do
+    desc 'Validate syntax for all ruby files'
+    task :syntax do
+      Dir.glob('**/*.rb').each do |ruby_file|
+        sh "ruby -c #{ruby_file}"
+      end
+      Dir.glob('**/*.erb').each do |erb_file|
+        sh "erb -P -x -T '-' #{erb_file} | ruby -c"
+      end
+    end
+  end
+
+end
+
+task :checks => ['check:manifests:syntax', 'check:manifests:lint', 'check:ruby:syntax']
+task :default => :checks

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -1,0 +1,7 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\MyCompany\MyKey') do
+  it { should exist }
+  it { should have_property_value('SubName', :type_string, "data") }
+end

--- a/spec/acceptance/deletekey_spec.rb
+++ b/spec/acceptance/deletekey_spec.rb
@@ -1,0 +1,10 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\MyCompany') do
+  it { should exist }
+end
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\MyCompany\MyKey') do
+  it { should_not exist }
+end

--- a/spec/acceptance/deletekeysubname_spec.rb
+++ b/spec/acceptance/deletekeysubname_spec.rb
@@ -1,0 +1,7 @@
+# Encoding: utf-8
+require_relative 'spec_windowshelper'
+
+describe windows_registry_key('HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\MyCompany\MyKey') do
+  it { should exist }
+  it { should_not have_property('SubName') }
+end

--- a/spec/acceptance/spec_windowshelper.rb
+++ b/spec/acceptance/spec_windowshelper.rb
@@ -1,0 +1,11 @@
+require 'serverspec'
+require 'winrm'
+
+set :backend, :winrm
+set :os, :family => 'windows'
+
+endpoint = "http://#{ENV['KITCHEN_HOSTNAME']}:#{ENV['KITCHEN_PORT']}/wsman"
+username = ENV['KITCHEN_USERNAME']
+password = 'vagrant' #sadly, no KITCHEN_PASSWORD variable at the time of writing.
+
+Specinfra.configuration.winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => username, :pass => password, :basic_auth_only => true).create_executor

--- a/spec/manifests/default.pp
+++ b/spec/manifests/default.pp
@@ -1,0 +1,6 @@
+
+registrykey { 'set MyCompany\MyKey':
+  key     => 'HKLM:\SOFTWARE\Wow6432Node\MyCompany\MyKey',
+  subName => 'SubName',
+  data    => 'data',
+}

--- a/spec/manifests/deletekey.pp
+++ b/spec/manifests/deletekey.pp
@@ -1,0 +1,4 @@
+registrykey { 'set MyCompany\MyKey':
+  ensure => 'absent',
+  key    => 'HKLM:\SOFTWARE\Wow6432Node\MyCompany\MyKey',
+}

--- a/spec/manifests/deletekeysubname.pp
+++ b/spec/manifests/deletekeysubname.pp
@@ -1,0 +1,5 @@
+registrykey { 'set MyCompany\MyKey':
+  ensure  => 'absent',
+  key     => 'HKLM:\SOFTWARE\Wow6432Node\MyCompany\MyKey',
+  subName => 'SubName',
+}

--- a/spec/vagrantfiles/create_keys.rb
+++ b/spec/vagrantfiles/create_keys.rb
@@ -1,0 +1,7 @@
+Vagrant.configure(2) do |config|
+  # Create registry keys so that we can test deleting them actually works
+  config.vm.provision "shell", inline: <<-SHELL
+    New-Item "HKLM:\\SOFTWARE\\Wow6432Node\\MyCompany\\MyKey" -Type Directory -Force
+    New-ItemProperty -Path "HKLM:\\SOFTWARE\\Wow6432Node\\MyCompany\\MyKey" -Name "SubName" -PropertyType "String" -Value "data"
+  SHELL
+end


### PR DESCRIPTION
registrykey now has a `ensure` parameter which defaults to `present`.

if `ensure` is `absent`, the registry key (or its subname only if present) is deleted.
- added some integration tests to confirm everything works...
